### PR TITLE
Lower CMake version requirement to 3.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.12)
 project("chdman CBT edition")
 set(build_version "0.238-CBT_edition")
 set(vcs_revision "mame0238")


### PR DESCRIPTION
This allows compiling chdman on a fresh Ubuntu 20.04 Docker container, without requiring a third-party repository for CMake (or building it from source).

This is useful to create chdman binaries that work on many Linux distributions, including LTS ones.

PS: If you're in a hurry and need compiled binaries that work on any recent Linux distribution, try the following:

- Standalone binary: [chdman.zip](https://github.com/CharlesThobe/chdman/files/10333190/chdman.zip)
- [Exodus](https://github.com/intoli/exodus) bundle generated from the standalone binary: [exodus-chdman-bundle.zip](https://github.com/CharlesThobe/chdman/files/10333191/exodus-chdman-bundle.zip)
  - The standalone binary didn't work on my Synology NAS, but the Exodus bundle did.